### PR TITLE
Fix: Nested management groups not identified using `management group` module

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -2,7 +2,7 @@ locals {
   tenant_id = data.azuread_client_config.current.tenant_id
 
   subscription_id  = var.onboarding_type == "single-subscription" ? data.azurerm_subscription.current[0].subscription_id : ""
-  subscription_ids = var.onboarding_type == "management-group" ? data.azurerm_management_group.current[0].subscription_ids : []
+  subscription_ids = var.onboarding_type == "management-group" ? data.azurerm_management_group.current[0].all_subscription_ids : []
 
   application_name = var.onboarding_type == "management-group" ? "aqua-cspm-scanner-${local.tenant_id}-${var.management_group_id}" : "aqua-cspm-scanner-${local.subscription_id}"
 }


### PR DESCRIPTION
Fix:

Nested management groups not identified using `management group` module

- Changed `data.azurerm_management_group` to fetch `all_subscription_ids` instead of `subscription_ids` in `locals.tf`