### PR TITLE
Fix: Eventgrid system topic error - only one system topic is allowed per source

### DIFF
--- a/modules/subscription/modules/eventgrid/main.tf
+++ b/modules/subscription/modules/eventgrid/main.tf
@@ -8,25 +8,22 @@ resource "azurerm_eventgrid_system_topic" "aqua_agentless_scanner" {
   tags                   = var.tags
 }
 
-
-resource "azurerm_eventgrid_event_subscription" "aqua_agentless_scanner" {
+resource "azurerm_eventgrid_system_topic_event_subscription" "aqua_agentless_scanner" {
   name                  = var.aqua_event_subscriptions_name
-  scope                 = var.resource_group_id
+  system_topic          = azurerm_eventgrid_system_topic.aqua_agentless_scanner.name
+  resource_group_name   = var.aqua_volscan_resource_group_name
   event_delivery_schema = "EventGridSchema"
-
-  advanced_filtering_on_arrays_enabled = true
-
   included_event_types = [
     "Microsoft.Resources.ResourceWriteSuccess",
     "Microsoft.Resources.ResourceDeleteSuccess",
   ]
+  advanced_filtering_on_arrays_enabled = true
 
   webhook_endpoint {
     url                               = var.aqua_volscan_api_url
     max_events_per_batch              = 1
     preferred_batch_size_in_kilobytes = 64
   }
-
   delivery_property {
     header_name = "x-vs-api-key"
     type        = "Static"


### PR DESCRIPTION
Fix: 

Eventgrid system topic error - only one system topic is allowed per source

- Switched `azurerm_eventgrid_event_subscription` to `azurerm_eventgrid_system_topic_event_subscription` in `eventgrid` module