### PR TITLE
RFE: Adding support for bringing your own service principal

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,7 +1,11 @@
 
 module "application" {
-  source           = "./modules/application"
-  application_name = local.application_name
+  source                      = "./modules/application"
+  application_name            = local.application_name
+  create_service_principal    = var.create_service_principal
+  application_id              = var.application_id
+  application_password        = var.application_password
+  service_principal_object_id = var.service_principal_object_id
 }
 
 module "iam" {

--- a/modules/application/README.md
+++ b/modules/application/README.md
@@ -34,7 +34,11 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_application_id"></a> [application\_id](#input\_application\_id) | Application ID - represented by the Service principal client ID associated with the application (in case that var.create\_service\_principal is false) | `string` | n/a | yes |
 | <a name="input_application_name"></a> [application\_name](#input\_application\_name) | Application Name | `string` | n/a | yes |
+| <a name="input_application_password"></a> [application\_password](#input\_application\_password) | Application password (in case that var.create\_service\_principal is false) | `string` | n/a | yes |
+| <a name="input_create_service_principal"></a> [create\_service\_principal](#input\_create\_service\_principal) | Toggle to create service principal | `bool` | n/a | yes |
+| <a name="input_service_principal_object_id"></a> [service\_principal\_object\_id](#input\_service\_principal\_object\_id) | Service principal object ID associated with the application (in case that var.create\_service\_principal is false) | `string` | n/a | yes |
 
 ## Outputs
 

--- a/modules/application/main.tf
+++ b/modules/application/main.tf
@@ -1,13 +1,16 @@
 resource "azuread_application" "aqua_cspm_scanner" {
+  count        = var.create_service_principal ? 1 : 0
   display_name = var.application_name
 }
 
 resource "azuread_application_password" "aqua_cspm_scanner" {
+  count             = var.create_service_principal ? 1 : 0
   display_name      = "rbac"
-  application_id    = "/applications/${azuread_application.aqua_cspm_scanner.object_id}"
+  application_id    = "/applications/${azuread_application.aqua_cspm_scanner[0].object_id}"
   end_date_relative = "262980h"
 }
 
 resource "azuread_service_principal" "aqua_cspm_scanner" {
-  client_id = azuread_application.aqua_cspm_scanner.client_id
+  count     = var.create_service_principal ? 1 : 0
+  client_id = azuread_application.aqua_cspm_scanner[0].client_id
 }

--- a/modules/application/outputs.tf
+++ b/modules/application/outputs.tf
@@ -1,16 +1,16 @@
 
 output "service_principal_object_id" {
-  value       = azuread_service_principal.aqua_cspm_scanner.object_id
+  value       = var.create_service_principal ? azuread_service_principal.aqua_cspm_scanner[0].object_id : var.service_principal_object_id
   description = "Service principal object ID associated with the application"
 }
 
 output "application_id" {
-  value       = azuread_service_principal.aqua_cspm_scanner.client_id
+  value       = var.create_service_principal ? azuread_service_principal.aqua_cspm_scanner[0].client_id : var.application_id
   description = "Application ID - represented by the Service principal client ID associated with the application"
 }
 
 output "application_password" {
-  value       = azuread_application_password.aqua_cspm_scanner.value
+  value       = var.create_service_principal ? azuread_application_password.aqua_cspm_scanner[0].value : var.application_password
   sensitive   = true
   description = "Application password"
 }

--- a/modules/application/variables.tf
+++ b/modules/application/variables.tf
@@ -2,3 +2,24 @@ variable "application_name" {
   type        = string
   description = "Application Name"
 }
+
+variable "create_service_principal" {
+  type        = bool
+  description = "Toggle to create service principal"
+}
+
+variable "service_principal_object_id" {
+  type        = string
+  description = "Service principal object ID associated with the application (in case that var.create_service_principal is false)"
+}
+
+variable "application_id" {
+  type        = string
+  description = "Application ID - represented by the Service principal client ID associated with the application (in case that var.create_service_principal is false)"
+}
+
+variable "application_password" {
+  type        = string
+  sensitive   = true
+  description = "Application password (in case that var.create_service_principal is false)"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -52,6 +52,31 @@ variable "create_network" {
   description = "Toggle to create network resources"
 }
 
+variable "create_service_principal" {
+  type        = bool
+  default     = true
+  description = "Toggle to create service principal"
+}
+
+variable "service_principal_object_id" {
+  type        = string
+  description = "Service principal object ID associated with the application (in case that var.create_service_principal is false)"
+  default     = ""
+}
+
+variable "application_id" {
+  type        = string
+  description = "Application ID - represented by the Service principal client ID associated with the application (in case that var.create_service_principal is false)"
+  default     = ""
+}
+
+variable "application_password" {
+  type        = string
+  sensitive   = true
+  description = "Application password (in case that var.create_service_principal is false)"
+  default     = ""
+}
+
 variable "aqua_volscan_scan_locations" {
   type = list(string)
   default = [


### PR DESCRIPTION
Adding support for bringing your own service principal

- Added variables `create_service_principal`, `service_principal_object_id`, `application_id`, `application_password` in `variables.tf` & `modules/application`
- Added `Using Existing Service Principal` section in `README.md`