### PR TITLE
RFE: Add `subscription_name` in the API call for single subscription onboarding

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -52,6 +52,7 @@ module "subscription" {
   onboarding_type                      = var.onboarding_type
   principal_id                         = module.application.service_principal_object_id
   subscription_id                      = data.azurerm_subscription.current[0].subscription_id
+  subscription_name                    = data.azurerm_subscription.current[0].display_name
   management_group_id                  = var.management_group_id
   tenant_id                            = local.tenant_id
   application_id                       = module.application.application_id

--- a/modules/subscription/README.md
+++ b/modules/subscription/README.md
@@ -65,6 +65,7 @@ This Terraform module creates the Single Subscription resources - on Azure.
 | <a name="input_onboarding_type"></a> [onboarding\_type](#input\_onboarding\_type) | The type of onboarding | `string` | n/a | yes |
 | <a name="input_principal_id"></a> [principal\_id](#input\_principal\_id) | The ID of the Service Principal to assign the Role Definition to | `string` | n/a | yes |
 | <a name="input_subscription_id"></a> [subscription\_id](#input\_subscription\_id) | Subscription ID | `string` | n/a | yes |
+| <a name="input_subscription_name"></a> [subscription\_name](#input\_subscription\_name) | Subscription Name | `string` | n/a | yes |
 | <a name="input_tenant_id"></a> [tenant\_id](#input\_tenant\_id) | Tenant ID | `string` | n/a | yes |
 
 ## Outputs

--- a/modules/subscription/modules/network/main.tf
+++ b/modules/subscription/modules/network/main.tf
@@ -14,9 +14,9 @@ resource "azurerm_virtual_network" "aqua_agentless_scanner" {
   location            = var.aqua_volscan_scan_locations[count.index]
   resource_group_name = var.aqua_volscan_resource_group_name
   subnet {
-    name                 = var.aqua_subnet_name
-    security_group       = azurerm_network_security_group.aqua_agentless_scanner[var.aqua_volscan_scan_locations[count.index]].id
-    address_prefix       = local.subnet_address_prefixes
+    name           = var.aqua_subnet_name
+    security_group = azurerm_network_security_group.aqua_agentless_scanner[var.aqua_volscan_scan_locations[count.index]].id
+    address_prefix = local.subnet_address_prefixes
   }
-  tags                = var.tags
+  tags = var.tags
 }

--- a/modules/subscription/trigger_discovery.py
+++ b/modules/subscription/trigger_discovery.py
@@ -14,6 +14,7 @@ aqua_api_key                     = query.get("aqua_api_key", "")
 aqua_api_secret                  = query.get("aqua_api_secret", "")
 application_password             = query.get("application_password", "")
 subscription_id                  = query.get("subscription_id", "")
+subscription_name                = query.get("subscription_name", "")
 aqua_cspm_group_id               = query.get("aqua_cspm_group_id", "")
 aqua_configuration_id            = query.get("aqua_configuration_id", "")
 organization_id                  = query.get("organization_id", "")
@@ -37,7 +38,7 @@ def get_headers():
     timestamp = str(int(time.time() * 1000))
     internal_signature = get_signature(aqua_api_secret, timestamp, get_signature_internal_path, "GET")
     body_cspm = ('{"autoconnect":true,"cloud":"azure","connection":{"azure":{"application_id":"' +
-                     application_id + '","directory_id":"' + directory_id + '","key_value":"' +
+                     application_id + '","directory_id":"' + directory_id + '","display_name":"' + subscription_name + '","key_value":"' +
                      application_password + '","subscription_id":"' + subscription_id +
                      '"}},"group_id":' + str(int(aqua_cspm_group_id)) + ',"name":"' + subscription_id + '"}'
                  )
@@ -61,6 +62,7 @@ def onboard_subscription():
         "deployment_method": deployment_method,
         "is_custom_name_vol_scan": is_custom_name_vol_scan,
         "resource_group_name_vol_scan": aqua_volscan_resource_group_name,
+        "subscription_name": subscription_name,
         "payload": {
             "subscription_id": subscription_id,
             "password": application_password,

--- a/modules/subscription/trigger_discovery.tf
+++ b/modules/subscription/trigger_discovery.tf
@@ -19,6 +19,7 @@ data "external" "autoconnect_trigger_discovery" {
     directory_id                     = var.tenant_id
     organization_id                  = var.management_group_id == "single-subscription" ? "" : var.management_group_id
     subscription_id                  = var.subscription_id
+    subscription_name                = var.subscription_name
     aqua_cspm_group_id               = var.aqua_cspm_group_id
     aqua_configuration_id            = var.aqua_configuration_id
     is_custom_name_vol_scan          = local.is_custom_name_vol_scan

--- a/modules/subscription/variables.tf
+++ b/modules/subscription/variables.tf
@@ -39,6 +39,11 @@ variable "subscription_id" {
   description = "Subscription ID"
 }
 
+variable "subscription_name" {
+  type        = string
+  description = "Subscription Name"
+}
+
 variable "aqua_custom_tags" {
   type        = map(string)
   description = "Client Additional Resource Tags"

--- a/variables.tf
+++ b/variables.tf
@@ -144,7 +144,6 @@ variable "aqua_system_topics_name" {
   description = "Aqua volume scanning Event Grid System Topic Name"
 }
 
-
 variable "aqua_event_subscriptions_name" {
   type        = string
   default     = "aqua-agentless-scanner"


### PR DESCRIPTION
Add `subscription_name` in the API call for single subscription onboarding

- Added variable `subscription_name` in `subscription` module.
- Added `subscription_name` in `trigger_discovery.py` API call
- Run Terraform fmt in `network` module
- Updated `README.md` to reflect the changes.