### PR TITLE
SLK-103546 - Add Token Authentication Fallback Support

### DIFF
--- a/modules/management_group/modules/continuous_onboarding/continuous_onboarding.py
+++ b/modules/management_group/modules/continuous_onboarding/continuous_onboarding.py
@@ -30,11 +30,13 @@ def get_headers(cspm_key, cspm_method='GET'):
     if cspm_key is not None:
         get_signature_cspm_path += "/" + cspm_key
     signature_cspm_keys = get_signature(aqua_api_secret, timestamp, get_signature_cspm_path, method=cspm_method)
+    tokens_signature = get_signature(aqua_api_secret, timestamp, "/v2/tokens", "POST", '{"validity":1,"allowed_endpoints":["ANY"]}')
 
     headers = {
         "X-API-Key": aqua_api_key,
         "X-Authenticate-Api-Key-Signature": internal_signature,
         "X-Register-New-Cspm-Signature": signature_cspm_keys,
+        "X-Tokens-Signature": tokens_signature,
         "X-Timestamp": timestamp
     }
 

--- a/modules/subscription/trigger_discovery.py
+++ b/modules/subscription/trigger_discovery.py
@@ -43,11 +43,13 @@ def get_headers():
                      '"}},"group_id":' + str(int(aqua_cspm_group_id)) + ',"name":"' + subscription_id + '"}'
                  )
     signature_cspm_keys = get_signature(aqua_api_secret, timestamp, get_signature_cspm_path, "POST", body_cspm)
+    tokens_signature = get_signature(aqua_api_secret, timestamp, "/v2/tokens", "POST", '{"validity":1,"allowed_endpoints":["ANY"]}')
 
     headers = {
         "X-API-Key": aqua_api_key,
         "X-Authenticate-Api-Key-Signature": internal_signature,
         "X-Register-New-Cspm-Signature": signature_cspm_keys,
+        "X-Tokens-Signature": tokens_signature,
         "X-Timestamp": timestamp
     }
     return headers


### PR DESCRIPTION
- Add X-Tokens-Signature header to all API key-authenticated requests
- Calculate tokens signature using existing get_signature function with /v2/tokens endpoint
- Update trigger-aws.py: add header to get_cspm_key_id(), trigger_discovery(), and update_credentials() functions
- Update create_cspm_key.py: add header to get_cspm_key_id() and create_cspm_key() functions
- Update generate_external_id.py: add header to generate_external_id() function
- Enable backend fallback to Bearer token authentication when API key authentication fails