### PR TITLE
SAAS-31622 - Onboarding | Azure | fix auto-detect scanning params for…

### DIFF
--- a/modules/management_group/locals.tf
+++ b/modules/management_group/locals.tf
@@ -5,4 +5,13 @@ locals {
   autoconnect_agentless_scanner_delete_role_definition = data.http.autoconnect_agentless_scanner_role.response_body
   aqua_agentless_delete_role_name                      = "aqua-agentless-scanner-delete-role-${var.management_group_id}"
   is_custom_name_vol_scan                              = tostring(var.aqua_volscan_resource_group_name != "aqua-agentless-scanner" || var.aqua_event_subscriptions_name != "aqua-agentless-scanner" || var.aqua_system_topics_name != "aqua-agentless-scanner" || var.aqua_subnet_name != "aqua-agentless-scanner")
+
+  # Auto-enable passing scanning params if user changed ANY module flag from default
+  should_pass_scanning_parameters = (
+    var.management_group_pass_scanning_parameters ||
+    var.volume_scanning_deployment != true ||
+    var.registry_scanning_deployment != true ||
+    var.serverless_scanning_deployment != true ||
+    var.base_cspm != false
+  )
 }

--- a/modules/management_group/main.tf
+++ b/modules/management_group/main.tf
@@ -104,7 +104,7 @@ resource "azurerm_management_group_template_deployment" "management_group_deploy
         "value" = local.is_custom_name_vol_scan
       },
     },
-    var.management_group_pass_scanning_parameters ? {
+    local.should_pass_scanning_parameters ? {
       "registryScanningDeployment" = {
         "value" = var.registry_scanning_deployment
       },


### PR DESCRIPTION
## Summary

Auto-enable passing scanning parameters to ARM template when user changes any module flag from its default value.

## Problem

When `management_group_pass_scanning_parameters` defaults to `false`, users who change module flags (e.g., `volume_scanning_deployment = false`) don't get their changes applied — the ARM template uses its own defaults instead.

## Solution

Added `local.should_pass_scanning_parameters` that auto-detects when any module flag differs from default:
- Old users (all defaults) → params NOT sent → works with old ARM template
- New users (changed any flag) → params ARE sent → works with new ARM template

## Changes

- `modules/management_group/locals.tf` — added `should_pass_scanning_parameters` local
- `modules/management_group/main.tf` — use new local instead of variable