### PR TITLE
fix(SAAS-31622): Onboarding | Azure | MG deployment to trigger for any enabled module

### DIFF
--- a/modules/management_group/main.tf
+++ b/modules/management_group/main.tf
@@ -10,8 +10,7 @@ module "continuous_onboarding" {
 
 
 resource "azurerm_management_group_template_deployment" "management_group_deployment" {
-  # Keep count plan-time deterministic; local.subscription_ids may be unknown until apply.
-  count = var.volume_scanning_deployment ? 1 : 0
+  # The ARM template handles conditional resource creation internally based on module flags.
   name                = "aqua-agentless-scanner"
   location            = local.aqua_volscan_template_location
   management_group_id = "/providers/Microsoft.Management/managementGroups/${var.management_group_id}"
@@ -106,16 +105,16 @@ resource "azurerm_management_group_template_deployment" "management_group_deploy
     },
     local.should_pass_scanning_parameters ? {
       "registryScanningDeployment" = {
-        "value" = var.registry_scanning_deployment
+        "value" = tostring(var.registry_scanning_deployment)
       },
       "serverlessScanningDeployment" = {
-        "value" = var.serverless_scanning_deployment
+        "value" = tostring(var.serverless_scanning_deployment)
       },
       "volumeScanningDeployment" = {
-        "value" = var.volume_scanning_deployment
+        "value" = tostring(var.volume_scanning_deployment)
       },
       "baseCspm" = {
-        "value" = var.base_cspm
+        "value" = tostring(var.base_cspm)
       },
     } : {},
     {


### PR DESCRIPTION
# Summary
The Management Group ARM template deployment was only triggered when `volume_scanning_deployment=true`. This prevented subscription registration and continuous onboarding setup when only CSPM, Registry, or Serverless modules were enabled.
## Changes
- Updated `count` condition in `modules/management_group/main.tf` to deploy when **any** module is enabled:
  - `volume_scanning_deployment = true`
  - `registry_scanning_deployment = true`
  - `serverless_scanning_deployment = true`
  - `base_cspm = false` (CSPM ON)
